### PR TITLE
Fix domain discernment for epicbox addresses

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -308,15 +308,19 @@ impl AsyncServer {
     }
 
     fn post_slate_federated(&self, from_address: &EpicboxAddress, to_address: &EpicboxAddress, str: String, signature: String, message_expiration_in_seconds: Option<u32>) -> EpicboxResponse {
+
+        let mut object: serde_json::Value = serde_json::from_str(&str).unwrap();
+        let domain = object["destination"]["domain"].as_str().unwrap();
+
         let url = match self.epicbox_protocol_unsecure {
             false => format!(
                 "wss://{}:{}",
-                to_address.domain,
+                domain,
                 to_address.port
             ),
             true => format!(
                 "ws://{}:{}",
-                to_address.domain,
+                domain,
                 to_address.port
             )
         };


### PR DESCRIPTION
-This PR resolves the localhost websockets SSL error below:
```
ERROR ws::handler] WS Error <Protocol>: Unable to parse domain from wss://[127.0.0.1/](https://127.0.0.1/). Needed for SSL
```

For some reason, our 'to_address' was not properly including our domain, nor port, and default behavior is to substitute `127.0.0.1:443`

Since ws requires a domain name for SSL validation (not an IP), this was causing an error and subsequent unresponsive hang behavior

Following this error, 'epoll' function causes epicbox to hang indefinitely because it is called with a `timeout=-1`. This commit does not resolve the timeout problem. Only domain discernment is addressed here.