### PR TITLE
update ring crate 0.13->0.16

### DIFF
--- a/epicboxlib/Cargo.toml
+++ b/epicboxlib/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4"
 parking_lot = {version = "0.6"}
 rand = "0.5"
 regex = "1"
-ring = "0.13"
+ring = "0.16"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"


### PR DESCRIPTION
This resolves an issue building projects which includes all of EpicCash/epic, EpicCash/epic-wallet, and EpicCash/epicbox, which have ring version inconsistencies which are resolved by this change